### PR TITLE
8 bit quantization support

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -21,16 +21,24 @@ parser.add_argument(
     action="store_true",
     help="Enable CPU offload for both OviFusionEngine and FluxPipeline"
 )
+parser.add_argument(
+    "--fp8",
+    action="store_true",
+    help="Enable 8 bit quantization of the fusion model",
+)
 args = parser.parse_args()
 
 
 # Initialize OviFusionEngine
 enable_cpu_offload = args.cpu_offload or args.use_image_gen
 use_image_gen = args.use_image_gen
-print(f"loading model... {enable_cpu_offload=}, {use_image_gen=} for gradio demo")
-DEFAULT_CONFIG['cpu_offload'] = enable_cpu_offload # always use cpu offload if image generation is enabled
-DEFAULT_CONFIG['mode'] = "t2v"  # hardcoded since it is always cpu offloaded
-ovi_engine = OviFusionEngine()
+fp8 = args.fp8
+print(f"loading model... {enable_cpu_offload=}, {use_image_gen=}, {fp8=} for gradio demo")
+DEFAULT_CONFIG["cpu_offload"] = (
+    enable_cpu_offload  # always use cpu offload if image generation is enabled
+)
+DEFAULT_CONFIG["mode"] = "t2v"  # hardcoded since it is always cpu offloaded
+ovi_engine = OviFusionEngine(fp8=fp8)
 flux_model = None
 if use_image_gen:
     flux_model = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-Krea-dev", torch_dtype=torch.bfloat16)

--- a/ovi/ovi_fusion_engine.py
+++ b/ovi/ovi_fusion_engine.py
@@ -52,7 +52,7 @@ class OviFusionEngine:
         self.vae_model_audio = vae_model_audio.bfloat16()
 
         # Load T5 text model
-        self.text_model = init_text_model(config.ckpt_dir, rank=device)
+        self.text_model = init_text_model(config.ckpt_dir, rank=device, cpu_offload=self.cpu_offload)
         if config.get("shard_text_model", False):
             raise NotImplementedError("Sharding text model is not implemented yet.")
         if self.cpu_offload:
@@ -297,6 +297,7 @@ class OviFusionEngine:
         model = model.cpu()
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
 
         return model
 

--- a/ovi/utils/model_loading_utils.py
+++ b/ovi/utils/model_loading_utils.py
@@ -59,7 +59,7 @@ def init_fusion_score_model_ovi(rank: int = 0, meta_init=False):
 
     return fusion_model, video_config, audio_config
 
-def init_text_model(ckpt_dir, rank):
+def init_text_model(ckpt_dir, rank, cpu_offload=False):
     wan_dir = os.path.join(ckpt_dir, "Wan2.2-TI2V-5B")
     text_encoder_path = os.path.join(wan_dir, "models_t5_umt5-xxl-enc-bf16.pth")
     text_tokenizer_path = os.path.join(wan_dir, "google/umt5-xxl")
@@ -70,6 +70,7 @@ def init_text_model(ckpt_dir, rank):
         device=rank,
         checkpoint_path=text_encoder_path,
         tokenizer_path=text_tokenizer_path,
+        cpu_offload=cpu_offload,
         shard_fn=None)
 
 


### PR DESCRIPTION
This PR makes it possible to run Ovi on a 24 GB GPU such as 3090 or 4090. The quantized model can be downloaded from here: https://huggingface.co/rkfg/Ovi-fp8_quantized/blob/main/model_fp8_e4m3fn.safetensors (put it to `./ckpts/Ovi/model_fp8_e4m3fn.safetensors`)
To use it, supply the memory optimization flags: `python gradio_app.py --cpu_offload --fp8`

I also make the VAEs move to RAM and back to squeeze a little more memory. The T5 encoder previously loaded to VRAM on startup even if CPU offload is used which caused a VRAM spike, I also changed that so it stays in RAM since startup. It slightly increased the initialization time.

I quantized all layers to 8 bit except those with `norm` and `bias` in the name, same as in Kijai's quants. The quality did suffer a little, maybe more layers should be left unquantized and it's something to experiment with later.

During the inference the process VRAM usage stays at around 16 GB but at the VAE stage it goes up to 19 GB. A tiled VAE should solve it but it's a lot more work and I don't think I'm competent enough for that 😅

Comparison, first the original 16 bit unquantized model, then the fp8_e4m3fn:

https://github.com/user-attachments/assets/aeca0597-ef0f-4b67-aec8-86d728f82026

https://github.com/user-attachments/assets/4611522e-7543-4902-b88f-53c052e65bb5

