### PR TITLE
Add qint8 quantization without downloading additional models

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ virtualenv ovi-env
 source ovi-env/bin/activate
 
 # Install PyTorch first
-pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1
+pip install torch==2.7.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu128
 
 # Install other dependencies
 pip install -r requirements.txt
@@ -121,6 +121,7 @@ To download our main Ovi checkpoint, as well as T5 and vae decoder from Wan, and
 ```
 # Default is downloaded to ./ckpts, and the inference yaml is set to ./ckpts so no change required
 python3 download_weights.py
+# For qint8 also ues python3 download_weights.py
 
 OR
 
@@ -214,6 +215,9 @@ OR
 python3 gradio_app.py --use_image_gen
 
 OR
+
+# To run model with 24Gb GPU vram. No need to download additional models.
+python3 gradio_app.py --cpu_offload --qint8
 
 # To run model with 24Gb GPU vram
 python3 gradio_app.py --cpu_offload --fp8

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ gradio
 open-clip-torch
 protobuf
 sentencepiece
+
+optimum-quanto


### PR DESCRIPTION
1. Add qint8 quantization. Using the same model as the original project, there is no need to download additional models.
2. Add a few convenient gradio startup parameters
3. Upgrade torch==2.7.0+cu128, available for personal testing. To adapt to 50 series graphics cards.
4. Added a startup example for qint8 quantification
5. Added wheel for qint8 quantification
6. Just to add, the repair codes for both [PR](https://github.com/character-ai/Ovi/pull/16) and [issue](https://github.com/character-ai/Ovi/issues/6) are from AIwood. Thank a lot.