### PR TITLE
Add output counter for video file naming

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -108,6 +108,7 @@ def main(config, args):
         # Distribute across SP groups
         this_rank_eval_data = all_eval_data[sp_group_id :: num_sp_groups]
 
+    output_counter=0
     for _, (text_prompt, image_path) in tqdm(enumerate(this_rank_eval_data)):
         video_frame_height_width = config.get("video_frame_height_width", None)
         seed = config.get("seed", 100)
@@ -135,10 +136,11 @@ def main(config, args):
             
             if sp_rank == 0:
                 formatted_prompt = format_prompt_for_filename(text_prompt)
-                output_path = os.path.join(output_dir, f"{formatted_prompt}_{'x'.join(map(str, video_frame_height_width))}_{seed+idx}_{global_rank}.mp4")
+                output_path = os.path.join(output_dir, f"{formatted_prompt}_{'x'.join(map(str, video_frame_height_width))}_{seed+idx}_{global_rank}_{output_counter}.mp4")
                 save_video(output_path, generated_video, generated_audio, fps=24, sample_rate=16000)
                 if generated_image is not None:
                     generated_image.save(output_path.replace('.mp4', '.png'))
+                output_counter=output_counter+1
         
 
 


### PR DESCRIPTION
Prevents similar named outputs from overwriting each other. Simple solution to avoid unwanted data loss.

Test by putting a series of long prompts into a batch where the beginning of the prompts are all the same:

```
text_prompt
" This is a test prompt that illustrates the issue of data loss where similar prompts will overwrite one another leading to unwanted data loss <S>Ovi is really cool, its pretty neat<E> <AUDCAP>Clear voice speaking<ENDAUDCAP>"
" This is a test prompt that illustrates the issue of data loss where similar prompts will overwrite one another leading to unwanted data loss <S>Ovi is really cool, its actually amazing<E> <AUDCAP>Clear voice speaking<ENDAUDCAP>"
" This is a test prompt that illustrates the issue of data loss where similar prompts will overwrite one another leading to unwanted data loss <S>Ovi is really cool, I really like Ovi<E> <AUDCAP>Clear voice speaking<ENDAUDCAP>"
```

The last prompt output will overwrite the other two on the filesystem. This PR offers a solution.